### PR TITLE
make json use nodeNext syntax

### DIFF
--- a/server/typescript/apiSpecAssembler.ts
+++ b/server/typescript/apiSpecAssembler.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 import baseLogger from "./logger.js"
-import { apiSpec as apiSpecBase } from './openapi.cjs'
+import { apiSpec as apiSpecBase } from './openapi.js'
 import type { OpenAPIV3 } from 'express-openapi-validator/dist/framework/types.js'
 import { Request, Response, RequestHandler, NextFunction } from 'express'
 

--- a/server/typescript/app.ts
+++ b/server/typescript/app.ts
@@ -2,7 +2,7 @@ import express, { Request, Response, NextFunction } from 'express'
 import cookieParser from 'cookie-parser'
 import morgan from 'morgan'
 import cors, { CorsOptions } from 'cors'
-import { apiSpec } from "./openapi.cjs"
+import { apiSpec } from "./openapi.js"
 import swaggerUi from 'swagger-ui-express'
 import OpenApiValidator from 'express-openapi-validator'
 import baseLogger from './logger.js'

--- a/server/typescript/openapi.cts
+++ b/server/typescript/openapi.cts
@@ -1,3 +1,0 @@
-import type { OpenAPIV3 } from 'express-openapi-validator/dist/framework/types.js'
-
-export const apiSpec: OpenAPIV3.DocumentV3 = require('../json/openapi.json')

--- a/server/typescript/openapi.ts
+++ b/server/typescript/openapi.ts
@@ -1,0 +1,5 @@
+import type { OpenAPIV3 } from 'express-openapi-validator/dist/framework/types.js'
+
+import openApiJson from '../json/openapi.json'  assert { type: 'json' }
+
+export const apiSpec = openApiJson as OpenAPIV3.DocumentV3

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "outDir": "server/ecmascript",
-    "module": "Node16",
+    "module": "NodeNext",
+    "resolveJsonModule": true,
     "strict": true
     //"removeComments": true
   },


### PR DESCRIPTION
The app currently does not run on MacOS with node v23.3.0 and typescript 5.7.3.

Switching from CJS to ESM syntax for the import of the JSON files solves the problem.